### PR TITLE
Test: Use the libarchive module from the runtime

### DIFF
--- a/org.libvips.nip4.json
+++ b/org.libvips.nip4.json
@@ -213,24 +213,6 @@
         },
 
         {
-            "name" : "libarchive",
-            "builddir" : true,
-            "buildsystem" : "cmake-ninja",
-            "build-options" : {
-                "config-opts" : [
-                    "-DCMAKE_INSTALL_LIBDIR=lib"
-                ]
-            },
-            "sources" : [
-                {
-                    "type" : "git",
-                    "url" : "https://github.com/libarchive/libarchive.git",
-                    "tag" : "v3.8.1"
-                }
-            ]
-        },
-
-        {
             "name" : "poppler-data",
             "builddir" : true,
             "buildsystem" : "cmake-ninja",


### PR DESCRIPTION
GNOME runtime version 49 (based on Freedesktop runtime version 25.08) provides the libarchive module.

In most cases, you don't need to build this module separately, unless your project requires a specific version or a custom configuration.

Fixes: https://github.com/flathub/org.libvips.nip4/issues/16